### PR TITLE
fix a bug for <div ng-transclude ><div>

### DIFF
--- a/ui-map.js
+++ b/ui-map.js
@@ -83,7 +83,7 @@
         return {
           restrict: 'EA',
           transclude: true,
-          template: '<div class="map-canvas"></div><div ng-transclude></div>',
+          template: '<div class="map-canvas"></div><div ng-transclude style="display:none"></div>',
           link: function (scope, elm, attrs) {
 
             var map,


### PR DESCRIPTION
add a style="display:none" for <div ng-transclude><div> ， this bug will dispaly  a blank block  in explorer，so make it hidden
